### PR TITLE
Update org-article.cls to support Chinese characters

### DIFF
--- a/README
+++ b/README
@@ -3,6 +3,14 @@
   - It is forked from https://github.com/tsdye/org-article.git
   
 * Update info
-  - Changing "#+source" to "#+name" such that org-babel-tangle works in new version of org-mode
+  - adding support for Chinese characters using the famous ctex package
+  
+  Now, by adding the two lines at the beginning of you Org file, everything follows up:
+  #+LaTeX_CLASS: org-article
+  #+LaTeX_CLASS_OPTIONS: [koma,ctex,a5paper,DIV=15,landscape,10pt,listings-sv,microtype,paralist]
+ 
+  Notice, the key is the ctex, the other options are backward compatible.
+  
+  Enjoy Emacs, Enjoy Latex.
 
-Mar 2015
+2018

--- a/org-article.cls
+++ b/org-article.cls
@@ -56,6 +56,8 @@
 \DeclareOption{utopia}{\setboolean{ORGART@utopia}{true}}
 \newboolean{ORGART@charter}
 \DeclareOption{charter}{\setboolean{ORGART@charter}{true}}
+\newboolean{ORGART@ctex}
+\DeclareOption{ctex}{\setboolean{ORGART@ctex}{true}}
 
 % Base class options
 \newboolean{koma}
@@ -509,6 +511,17 @@
    \RequirePackage{courier} % tt
   \fi}%
 {}  
+\ifthenelse{\boolean{ORGART@ctex}}
+{%
+  \ifpdf
+   \RequirePackage[UTF8]{ctex}
+   \RequirePackage[T1]{fontenc}
+   \RequirePackage[adobe-utopia]{mathdesign}
+   \RequirePackage[scaled]{berasans}
+   \RequirePackage{inconsolata} % tt
+  \fi}%
+{}
+
 \ifthenelse{\boolean{ORGART@utopia}}
 {%
   \ifpdf


### PR DESCRIPTION
Hi, it has been long time since after updte of this repository. Right now, I modify it to support Chinese characters using the famous ctex package

Now, by adding the following two lines, you can generate PDF supporting Chinese charaters using Org

#+LaTeX_CLASS: org-article
#+LaTeX_CLASS_OPTIONS: [koma,ctex,a5paper,landscape,10pt,listings-sv,microtype,paralist]

Here, the key part is adding ctex, and for other options it is backward compatibile.